### PR TITLE
chore(charts): bump Horizon appVersion 35.0.5 → 36.0.0 (chart 0.3.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). All
 
 (no unreleased changes yet)
 
+## [0.3.1] — 2026-05-23
+
+### Changed
+
+- **All four charts** — `appVersion` bumped from `35.0.5` to `36.0.0` (latest stable OpenNMS Horizon release, published 2026-05-12). Chart values surface and templates are unchanged; the bump is image-only. Horizon 36.0.0 introduces DB-backed configuration for SNMP, data collection, Trapd, and eventconf — these schema migrations are applied automatically by Liquibase at Core boot on first install or upgrade.
+- **`minion`** — chart `version` bumped from `0.2.0` to `0.3.1` to re-establish the lock-step convention (`core`, `sentinel`, `minion`, `opennms-stack` all release together with the same chart `version`). The 0.2.0 → 0.3.1 jump skips a `0.3.0` Minion tag — Minion was not affected by 0.3.0's Postgres-surface change and was deliberately left behind; this release brings it back in line.
+- **All four charts** — strict-pin cascade: `core`, `sentinel`, `minion`, `opennms-stack` all at `0.3.1`. Umbrella `dependencies` strict-pin updated to `=0.3.1` for both `core` and `sentinel`.
+
+### Notes
+
+- Existing 0.3.0 (Horizon 35.0.5) installs upgrading to 0.3.1 will trigger the 35.x → 36.x Liquibase migration on the next Core pod restart. Snapshot the database first.
+- Fresh 0.3.1 installs against an empty database run the 36.0.0 schema bootstrap end-to-end — no migration involved.
+
 ## [0.3.0] — 2026-05-22
 
 ### Added
@@ -85,7 +98,8 @@ First published release of the OpenNMS Helm Charts.
 - `core.postgresql.host` defaults to a CNPG-specific hostname (`cluster-helm-lint-rw.default.svc.cluster.local`) used by the in-repo chart-testing flow. Production users must set `postgresql.host` explicitly — the chart fails template-time on missing host.
 - The optional `prometheus-remote-writer` plugin is downloaded from GitHub Releases at every pod start when enabled. Air-gapped clusters override `prometheusRemoteWriter.kar.url` to an internal mirror.
 
-[Unreleased]: https://github.com/labmonkeys-space/opennms-helm-charts/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/labmonkeys-space/opennms-helm-charts/compare/v0.3.1...HEAD
+[0.3.1]: https://github.com/labmonkeys-space/opennms-helm-charts/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/labmonkeys-space/opennms-helm-charts/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/labmonkeys-space/opennms-helm-charts/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/labmonkeys-space/opennms-helm-charts/releases/tag/v0.1.0

--- a/charts/core/Chart.yaml
+++ b/charts/core/Chart.yaml
@@ -20,10 +20,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "35.0.5"
+appVersion: "36.0.0"

--- a/charts/core/README.md
+++ b/charts/core/README.md
@@ -1,6 +1,6 @@
 # core
 
-![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 35.0.5](https://img.shields.io/badge/AppVersion-35.0.5-informational?style=flat-square)
+![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 36.0.0](https://img.shields.io/badge/AppVersion-36.0.0-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 

--- a/charts/minion/Chart.yaml
+++ b/charts/minion/Chart.yaml
@@ -20,10 +20,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "35.0.5"
+appVersion: "36.0.0"

--- a/charts/minion/README.md
+++ b/charts/minion/README.md
@@ -1,6 +1,6 @@
 # minion
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 35.0.5](https://img.shields.io/badge/AppVersion-35.0.5-informational?style=flat-square)
+![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 36.0.0](https://img.shields.io/badge/AppVersion-36.0.0-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 

--- a/charts/opennms-stack/Chart.lock
+++ b/charts/opennms-stack/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: core
   repository: file://../core
-  version: 0.3.0
+  version: 0.3.1
 - name: sentinel
   repository: file://../sentinel
-  version: 0.3.0
-digest: sha256:86035a506aea2a938c489e3bb6cb6f0391b47bd0169ddf75388c4e1def5d682f
-generated: "2026-05-22T10:04:42.316203+02:00"
+  version: 0.3.1
+digest: sha256:ae79d5349e6858eaa529091f2432c4bea0760745c1253dd05c51e10bf4bcc004
+generated: "2026-05-23T00:01:25.364011+02:00"

--- a/charts/opennms-stack/Chart.yaml
+++ b/charts/opennms-stack/Chart.yaml
@@ -14,19 +14,19 @@ maintainers:
 type: application
 
 # Bump this version whenever any pinned subchart version changes.
-version: 0.3.0
+version: 0.3.1
 
 # Lock-step with the bundled OpenNMS components (Core and Sentinel both run
 # this version of Horizon).
-appVersion: "35.0.5"
+appVersion: "36.0.0"
 
 # Strict-pin subchart versions. The matched-pair invariant — Core and Sentinel
 # must run the same OpenNMS major version due to shared JPA schema and Karaf
 # features — is enforced here at the umbrella level.
 dependencies:
   - name: core
-    version: "=0.3.0"
+    version: "=0.3.1"
     repository: file://../core
   - name: sentinel
-    version: "=0.3.0"
+    version: "=0.3.1"
     repository: file://../sentinel

--- a/charts/opennms-stack/README.md
+++ b/charts/opennms-stack/README.md
@@ -1,6 +1,6 @@
 # opennms-stack
 
-![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 35.0.5](https://img.shields.io/badge/AppVersion-35.0.5-informational?style=flat-square)
+![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 36.0.0](https://img.shields.io/badge/AppVersion-36.0.0-informational?style=flat-square)
 
 Umbrella Helm chart bundling OpenNMS Horizon Core and Sentinel for the
 central OpenNMS site. Connects to BYO Postgres, Kafka, and Elasticsearch.
@@ -17,8 +17,8 @@ this umbrella.
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../core | core | =0.3.0 |
-| file://../sentinel | sentinel | =0.3.0 |
+| file://../core | core | =0.3.1 |
+| file://../sentinel | sentinel | =0.3.1 |
 
 ## Values
 

--- a/charts/sentinel/Chart.yaml
+++ b/charts/sentinel/Chart.yaml
@@ -19,10 +19,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "35.0.5"
+appVersion: "36.0.0"

--- a/charts/sentinel/README.md
+++ b/charts/sentinel/README.md
@@ -1,6 +1,6 @@
 # sentinel
 
-![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 35.0.5](https://img.shields.io/badge/AppVersion-35.0.5-informational?style=flat-square)
+![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 36.0.0](https://img.shields.io/badge/AppVersion-36.0.0-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 


### PR DESCRIPTION
## Summary

- Bump `appVersion` from `35.0.5` to `36.0.0` (the latest stable OpenNMS Horizon release, published 2026-05-12). Image-only — chart values surface and templates are unchanged.
- Chart `version` 0.3.0 → 0.3.1 across `core`, `sentinel`, `opennms-stack`. **`minion`** catches up from 0.2.0 → 0.3.1 to re-establish the README's lock-step convention (Minion was deliberately left behind in 0.3.0 because its templates were unaffected by that release's Postgres-surface change).
- Umbrella `dependencies` strict-pin updated to `=0.3.1`.

## Heads-up for existing 0.3.0 deployments

Horizon 36.0.0 introduces DB-backed configuration for SNMP, data collection, Trapd, and eventconf. Liquibase will apply the 35.x → 36.x schema migrations on the first Core pod boot after upgrade. **Snapshot the Postgres database before rolling Core.**

Fresh installs against an empty database (e.g. CNPG-managed new cluster) run the 36.0.0 schema bootstrap end-to-end — no migration involved.

## Test plan

- [x] `helm lint` clean for the umbrella against `ci/test-values.yaml`
- [x] `helm template` renders `docker.io/opennms/horizon:36.0.0`, `docker.io/opennms/sentinel:36.0.0`, chart labels `core-0.3.1` / `sentinel-0.3.1`
- [x] `helm-docs` regenerated all four READMEs (version badges 0.3.1, appVersion 36.0.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)