### PR TITLE
fix(charts)!: switch Core Kafka IPC to opennms.properties (0.3.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). All
 
 (no unreleased changes yet)
 
+## [0.3.2] — 2026-05-23
+
+### Fixed
+
+- **`core`** — Kafka IPC config is now written as system properties in `opennms.properties.d/kafka-ipc.properties` with the `org.opennms.core.ipc.kafka.` prefix, instead of `.cfg` files plus `featuresBoot.d/kafka-*.boot` directives. Core reads Kafka IPC config via `OnmsKafkaConfigProvider` (system-property scan, prefix-stripped), not Karaf ConfigAdmin — the `.cfg` writes were dead, and the `featuresBoot.d` writes referenced `opennms-core-ipc-{rpc,sink,twin}-kafka` features whose implementation bundles (`org.opennms.core.ipc.rpc.kafka`, `org.opennms.core.ipc.sink.kafka.client`, `org.opennms.core.ipc.twin.kafka.subscriber`) are not shipped in the `opennms/horizon:36.0.0` (and `35.x`) OCI image. The Karaf resolver consequently fails at boot with `Error downloading mvn:...` and Core never starts when `kafka.bootstrapServers` is set. The new path matches what `OpenNMSContainer.java` in the upstream smoke harness does — and is the only path that actually works on the published Horizon image.
+
+### Changed
+
+- **All four charts** — strict-pin cascade: `core`, `sentinel`, `minion`, `opennms-stack` all bump from `0.3.1` to `0.3.2`. Umbrella `dependencies` strict-pin updated to `=0.3.2`. `sentinel` and `minion` chart contents are unchanged; the bump preserves the lock-step convention.
+
+### Breaking changes (upgrade impact for 0.3.1 → 0.3.2 users)
+
+- **`core` — three `.cfg` paths and four `featuresBoot.d` paths in the Core etc-overlay are gone.** Operators who set `extraConfigFiles."org.opennms.core.ipc.{sink,rpc,twin}.kafka.cfg": ...` or `extraConfigFiles."featuresBoot.d/kafka-{ipc,rpc,sink,twin}.boot": ...` to override the chart-managed entries will still see their content written to the etc-overlay, but it will no longer be matched by a chart-managed entry — those overrides become inert dead writes that Core does not read. Re-express any Kafka client tunings as `kafka.extraProperties` (rendered with the `org.opennms.core.ipc.kafka.` prefix into the new properties file) instead.
+
+### Known limitations (unchanged)
+
+- **Functional Kafka TLS is still not wired** in any of the three charts. `kafka.tls.enabled=true` flips the protocol to `SSL` / `SASL_SSL`, but the chart does NOT mount the `tls.existingSecret` into the pod or emit `ssl.truststore.location` / `ssl.keystore.location` properties. For TLS-encrypted Kafka right now, operators must mount the Secret and emit the truststore properties via `extraConfigFiles` themselves. Full TLS wiring is targeted for a follow-up release across all three charts in lock-step.
+
 ## [0.3.1] — 2026-05-23
 
 ### Changed
@@ -98,7 +116,8 @@ First published release of the OpenNMS Helm Charts.
 - `core.postgresql.host` defaults to a CNPG-specific hostname (`cluster-helm-lint-rw.default.svc.cluster.local`) used by the in-repo chart-testing flow. Production users must set `postgresql.host` explicitly — the chart fails template-time on missing host.
 - The optional `prometheus-remote-writer` plugin is downloaded from GitHub Releases at every pod start when enabled. Air-gapped clusters override `prometheusRemoteWriter.kar.url` to an internal mirror.
 
-[Unreleased]: https://github.com/labmonkeys-space/opennms-helm-charts/compare/v0.3.1...HEAD
+[Unreleased]: https://github.com/labmonkeys-space/opennms-helm-charts/compare/v0.3.2...HEAD
+[0.3.2]: https://github.com/labmonkeys-space/opennms-helm-charts/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/labmonkeys-space/opennms-helm-charts/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/labmonkeys-space/opennms-helm-charts/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/labmonkeys-space/opennms-helm-charts/compare/v0.1.0...v0.2.0

--- a/charts/core/Chart.yaml
+++ b/charts/core/Chart.yaml
@@ -20,7 +20,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.1
+version: 0.3.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/core/README.md
+++ b/charts/core/README.md
@@ -1,6 +1,6 @@
 # core
 
-![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 36.0.0](https://img.shields.io/badge/AppVersion-36.0.0-informational?style=flat-square)
+![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 36.0.0](https://img.shields.io/badge/AppVersion-36.0.0-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 

--- a/charts/core/templates/_helpers.tpl
+++ b/charts/core/templates/_helpers.tpl
@@ -256,19 +256,22 @@ Kafka SASL security protocol — adjusts based on whether TLS is also enabled.
 {{- end }}
 
 {{/*
-Kafka .cfg body shared by sink, rpc, and twin .cfg files. Emits bootstrap.servers,
-security.protocol, optional SASL block (with envsubst placeholders for credentials),
-and any extraProperties.
+Kafka IPC system properties for opennms.properties.d/. Core reads Kafka client
+config from system properties (not Karaf ConfigAdmin .cfg files): the
+org.opennms.core.ipc.kafka.* prefix is stripped by OnmsKafkaConfigProvider
+(opennms-project: core/ipc/common/kafka/.../OnmsKafkaConfigProvider.java) and
+the remainder is fed to the Kafka client.
 */}}
-{{- define "core.kafkaCfgBlock" -}}
-bootstrap.servers={{ include "core.kafkaBootstrap" . }}
-security.protocol={{ include "core.kafkaSecurityProtocol" . }}
+{{- define "core.kafkaSysPropsBlock" -}}
+org.opennms.core.ipc.strategy=kafka
+org.opennms.core.ipc.kafka.bootstrap.servers={{ include "core.kafkaBootstrap" . }}
+org.opennms.core.ipc.kafka.security.protocol={{ include "core.kafkaSecurityProtocol" . }}
 {{- if .Values.kafka.auth.enabled }}
-sasl.mechanism={{ .Values.kafka.auth.mechanism }}
-sasl.jaas.config={{ include "core.kafkaJaasModule" . }} required username="${KAFKA_USERNAME}" password="${KAFKA_PASSWORD}";
+org.opennms.core.ipc.kafka.sasl.mechanism={{ .Values.kafka.auth.mechanism }}
+org.opennms.core.ipc.kafka.sasl.jaas.config={{ include "core.kafkaJaasModule" . }} required username="${KAFKA_USERNAME}" password="${KAFKA_PASSWORD}";
 {{- end }}
 {{- range $k, $v := .Values.kafka.extraProperties }}
-{{ $k }}={{ $v }}
+org.opennms.core.ipc.kafka.{{ $k }}={{ $v }}
 {{- end }}
 {{- end }}
 

--- a/charts/core/templates/core-config-templates.yaml
+++ b/charts/core/templates/core-config-templates.yaml
@@ -16,21 +16,18 @@
 {{- $_ := set $files "opennms.properties.d/instance-id.properties" (printf "org.opennms.instance.id=%s\n" (include "core.instanceId" .)) -}}
 
 {{- if include "core.kafkaBootstrap" . -}}
-{{- /* Per-channel Karaf .cfg files — broker, security protocol, optional SASL */ -}}
-{{- $kafkaCfg := include "core.kafkaCfgBlock" . -}}
-{{- $_ := set $files "org.opennms.core.ipc.sink.kafka.cfg" $kafkaCfg -}}
-{{- $_ := set $files "org.opennms.core.ipc.rpc.kafka.cfg" $kafkaCfg -}}
-{{- $_ := set $files "org.opennms.core.ipc.twin.kafka.cfg" $kafkaCfg -}}
+{{- /* Core reads Kafka IPC config from opennms.properties system properties,
+       not Karaf ConfigAdmin .cfg files. OnmsKafkaConfigProvider strips the
+       org.opennms.core.ipc.kafka.* prefix and hands the rest to the Kafka
+       client. The per-channel kafka feature bundles
+       (opennms-core-ipc-{rpc,sink,twin}-kafka) are NOT shipped in the Horizon
+       OCI image — features.xml references them but opennms-full-assembly
+       doesn't pull them in. Writing featuresBoot.d entries for those features
+       breaks Karaf bundle resolution at boot. */ -}}
+{{- $_ := set $files "opennms.properties.d/kafka-ipc.properties" (printf "%s\n" (include "core.kafkaSysPropsBlock" .)) -}}
 {{- /* Disable the embedded ActiveMQ broker — Core is Kafka-only here.
        Without this the broker still starts on port 61616 alongside Kafka. */ -}}
 {{- $_ := set $files "opennms.properties.d/disable-activemq.properties" "org.opennms.activemq.broker.disable=true\n" -}}
-{{- /* Karaf featuresBoot — disable the JMS IPC features, enable Kafka.
-       Mirrors charts/minion/templates/minion-config-templates.yaml without the
-       Minion-specific !minion-jms line. */ -}}
-{{- $_ := set $files "featuresBoot.d/kafka-ipc.boot" "!opennms-core-ipc-jms\nopennms-core-ipc-kafka\n" -}}
-{{- $_ := set $files "featuresBoot.d/kafka-rpc.boot" "!opennms-core-ipc-rpc-jms\nopennms-core-ipc-rpc-kafka\n" -}}
-{{- $_ := set $files "featuresBoot.d/kafka-sink.boot" "!opennms-core-ipc-sink-camel\nopennms-core-ipc-sink-kafka\n" -}}
-{{- $_ := set $files "featuresBoot.d/kafka-twin.boot" "!opennms-core-ipc-twin-jms\nopennms-core-ipc-twin-kafka\n" -}}
 {{- end }}
 
 {{- if .Values.elasticsearch.enabled }}

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -231,7 +231,10 @@ postgresql:
 
 # BYO Kafka. This chart NEVER deploys Kafka.
 #
-# Renders org.opennms.core.ipc.{sink,rpc,twin}.kafka.cfg into the etc-overlay.
+# Renders Kafka client properties into opennms.properties.d/kafka-ipc.properties
+# with the `org.opennms.core.ipc.kafka.` prefix. OnmsKafkaConfigProvider strips
+# the prefix and hands the rest to the Kafka client (Core reads IPC config from
+# system properties, not Karaf ConfigAdmin .cfg files).
 # When `auth.enabled` is true, the chart references `auth.existingSecret`
 # whose keys MUST be: KAFKA_USERNAME, KAFKA_PASSWORD.
 # When `tls.enabled` is true, `tls.existingSecret` must contain `ca.crt`
@@ -246,7 +249,8 @@ kafka:
   tls:
     enabled: false
     existingSecret: ""
-  # Passthrough Kafka client properties merged into all three .cfg files.
+  # Passthrough Kafka client properties prefixed with org.opennms.core.ipc.kafka.
+  # in opennms.properties.d/kafka-ipc.properties.
   extraProperties: {}
     # compression.type: gzip
     # request.timeout.ms: "30000"

--- a/charts/minion/Chart.yaml
+++ b/charts/minion/Chart.yaml
@@ -20,7 +20,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.1
+version: 0.3.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/minion/README.md
+++ b/charts/minion/README.md
@@ -1,6 +1,6 @@
 # minion
 
-![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 36.0.0](https://img.shields.io/badge/AppVersion-36.0.0-informational?style=flat-square)
+![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 36.0.0](https://img.shields.io/badge/AppVersion-36.0.0-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 

--- a/charts/opennms-stack/Chart.lock
+++ b/charts/opennms-stack/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: core
   repository: file://../core
-  version: 0.3.1
+  version: 0.3.2
 - name: sentinel
   repository: file://../sentinel
-  version: 0.3.1
-digest: sha256:ae79d5349e6858eaa529091f2432c4bea0760745c1253dd05c51e10bf4bcc004
-generated: "2026-05-23T00:01:25.364011+02:00"
+  version: 0.3.2
+digest: sha256:4f81c27fa64a384f846ff784aafc595828df56696cc9e91be11c6a4ee17ea87b
+generated: "2026-05-23T22:25:15.394006+02:00"

--- a/charts/opennms-stack/Chart.yaml
+++ b/charts/opennms-stack/Chart.yaml
@@ -14,7 +14,7 @@ maintainers:
 type: application
 
 # Bump this version whenever any pinned subchart version changes.
-version: 0.3.1
+version: 0.3.2
 
 # Lock-step with the bundled OpenNMS components (Core and Sentinel both run
 # this version of Horizon).
@@ -25,8 +25,8 @@ appVersion: "36.0.0"
 # features — is enforced here at the umbrella level.
 dependencies:
   - name: core
-    version: "=0.3.1"
+    version: "=0.3.2"
     repository: file://../core
   - name: sentinel
-    version: "=0.3.1"
+    version: "=0.3.2"
     repository: file://../sentinel

--- a/charts/opennms-stack/README.md
+++ b/charts/opennms-stack/README.md
@@ -1,6 +1,6 @@
 # opennms-stack
 
-![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 36.0.0](https://img.shields.io/badge/AppVersion-36.0.0-informational?style=flat-square)
+![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 36.0.0](https://img.shields.io/badge/AppVersion-36.0.0-informational?style=flat-square)
 
 Umbrella Helm chart bundling OpenNMS Horizon Core and Sentinel for the
 central OpenNMS site. Connects to BYO Postgres, Kafka, and Elasticsearch.
@@ -17,8 +17,8 @@ this umbrella.
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../core | core | =0.3.1 |
-| file://../sentinel | sentinel | =0.3.1 |
+| file://../core | core | =0.3.2 |
+| file://../sentinel | sentinel | =0.3.2 |
 
 ## Values
 

--- a/charts/sentinel/Chart.yaml
+++ b/charts/sentinel/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.1
+version: 0.3.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/sentinel/README.md
+++ b/charts/sentinel/README.md
@@ -1,6 +1,6 @@
 # sentinel
 
-![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 36.0.0](https://img.shields.io/badge/AppVersion-36.0.0-informational?style=flat-square)
+![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 36.0.0](https://img.shields.io/badge/AppVersion-36.0.0-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 


### PR DESCRIPTION
## Summary

- **Bug**: `core` chart Kafka IPC is broken on `opennms/horizon:36.0.0` (and was already broken on 35.x — undetected) — Karaf fails to resolve `mvn:org.opennms.core.ipc.rpc/org.opennms.core.ipc.rpc.kafka/36.0.0` at boot, and Core never starts when `kafka.bootstrapServers` is set.
- **Root cause**: chart drove Kafka IPC via Karaf ConfigAdmin `.cfg` files plus `featuresBoot.d/kafka-*.boot` directives referencing per-channel features (`opennms-core-ipc-{rpc,sink,twin}-kafka`). The features.xml in the image defines these features, but `opennms-full-assembly` does not pull in their implementation bundles (`org.opennms.core.ipc.{rpc,sink,twin}.kafka`). Bundle inventory in `/opt/opennms/system/` is identical between 35.0.5 and 36.0.0 — those bundles have never shipped. The chart's previous path therefore never worked end-to-end.
- **Fix**: Core reads Kafka IPC config via `OnmsKafkaConfigProvider` — a system-property scan with prefix `org.opennms.core.ipc.kafka.` stripped before being handed to the Kafka client. The chart now writes a single `opennms.properties.d/kafka-ipc.properties` with `org.opennms.core.ipc.strategy=kafka` plus the prefixed Kafka client config. This matches what upstream's smoke harness (`smoke-test/.../OpenNMSContainer.java:382-386`) does, and is the path that actually works on the published Horizon image.
- **Lock-step bump**: all four charts 0.3.1 → 0.3.2; umbrella strict-pins regenerated.

## Test plan

- [x] `helm lint` clean on `core`, `sentinel`, `minion`, `opennms-stack`.
- [x] `helm template charts/core` renders the new properties file correctly for PLAINTEXT, SASL_PLAINTEXT, and SASL_SSL paths.
- [x] `helm template charts/opennms-stack` end-to-end with the regenerated 0.3.2 subchart tarballs renders the same file.
- [x] With `kafka.bootstrapServers` empty no Kafka file is rendered (chart-gated correctly).
- [x] Helm-docs regen — `make readme` updates version badges to 0.3.2.
- [ ] **Deploy against a real Kafka and confirm Core starts and Minion RPC roundtrip works.** Chart-testing CI does not exercise this; manual verification required before tag.

## Breaking changes (operators upgrading 0.3.1 → 0.3.2)

- Three `.cfg` paths (`org.opennms.core.ipc.{sink,rpc,twin}.kafka.cfg`) and four `featuresBoot.d/kafka-*.boot` paths are no longer chart-managed. Anyone overriding them via `extraConfigFiles` will still see their content written to the etc-overlay, but it will not be matched against a chart-managed entry — those overrides become inert dead writes. Re-express Kafka client tunings as `kafka.extraProperties` (rendered with the `org.opennms.core.ipc.kafka.` prefix into the new properties file).

## Known limitation (unchanged)

- `kafka.tls.enabled=true` still only flips `security.protocol` to `SSL` / `SASL_SSL`; the truststore is not mounted and `ssl.truststore.location` is not emitted. Functional TLS wiring is targeted for a follow-up lock-step release across `core`, `sentinel`, `minion`.

## Why CI didn't catch this

- This repo's chart-testing matrix does not exercise a real Minion-Core-Kafka roundtrip.
- Upstream OpenNMS smoke (`smoke-test-minion` suite, CircleCI) uses the system-property switch and never installs any kafka IPC Karaf feature — so the broken feature path is unreachable from any upstream test.
- A simple post-build check — `xmllint --xpath '//bundle/text()' features.xml | while read coord; do test -e <resolved path>; done` — would have caught the upstream packaging gap immediately. Worth proposing to OpenNMS as a follow-up.