### PR TITLE
fix(charts)!: cleanup stale featuresBoot files + per-daemon disable surface (0.3.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,30 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). All
 
 (no unreleased changes yet)
 
+## [0.3.3] — 2026-05-24
+
+### Fixed
+
+- **`core`** — Stale `featuresBoot.d/kafka-{ipc,rpc,sink,twin}.boot` files written by chart ≤0.3.1 now get removed from the persistent etc directory at every pod start. The 0.3.2 fix stopped *writing* these files, but the upstream entrypoint's `applyOverlayConfig` is additive — files dropped from the chart's overlay survive on the PVC across upgrades. Result on 0.3.1→0.3.2 upgrade: Karaf failed with `Error resolving artifact org.opennms.core.ipc.rpc:org.opennms.core.ipc.rpc.kafka:jar:36.0.0` and Core never started. 0.3.3 extends the envsubst init container to mount the PVC and `rm -f` the four well-known stale paths before the install container runs.
+
+### Added
+
+- **`core`** — new `core.daemons.<short-name>.enabled` values surface for per-daemon enable/disable. Upstream `etc/service-configuration.xml` already wraps every Core daemon's `enabled` attribute in `${env:CORE_SERVICE_<NAME>_ENABLED|<default>}`, so the chart projects a `CORE_SERVICE_<STEM>_ENABLED=false` env var into both Core containers when an operator flips `enabled: false` — no XML editing, no extra init container, no init image expansion. First (and only) wired daemon: `ackd`. Unknown short-names fail `helm template` with a clear error listing the whitelist. Adding the next daemon is one entry in `core.daemonsEnvWhitelist` (`charts/core/templates/_helpers.tpl`) plus one entry in `values.yaml`.
+
+### Changed
+
+- **`core`** — `daemons.ackd.enabled` defaults to `false`. Ackd is on the upstream deprecation track and most deployments don't use it. Operators who still rely on alarm acknowledgement workflows that depend on Ackd MUST set `core.daemons.ackd.enabled: true` explicitly on upgrade.
+- **All four charts** — strict-pin cascade: `core`, `sentinel`, `minion`, `opennms-stack` all bump from `0.3.2` to `0.3.3`. Umbrella `dependencies` strict-pin updated to `=0.3.3`. `sentinel` and `minion` chart contents are unchanged; the bump preserves the lock-step convention.
+
+### Breaking changes (upgrade impact for 0.3.2 → 0.3.3 users)
+
+- **`core` — Ackd is disabled by default.** Existing 0.3.2 deployments that depended on the upstream `enabled="true"` default for Ackd will see the daemon silently switched off after the upgrade. Mitigation: set `core.daemons.ackd.enabled: true` in your values before upgrading. The chart prints no warning when Ackd is disabled (the values block is the source of truth).
+- **`core` — operator-supplied `extraConfigFiles."featuresBoot.d/kafka-{ipc,rpc,sink,twin}.boot"` files will be deleted from the PVC at every pod start.** The cleanup `rm -f` runs unconditionally and targets exact filenames; the operator's overlay re-renders the files on each install, but the cleanup runs before the overlay copy. Mitigation: if you depend on bespoke `kafka-*.boot` content (unlikely — the bundles don't ship in any Horizon 35/36 image), rename to a non-conflicting filename.
+
+### Known limitations (unchanged)
+
+- **Functional Kafka TLS is still not wired** in any of the three charts. `kafka.tls.enabled=true` flips the protocol to `SSL` / `SASL_SSL`, but the chart does NOT mount the `tls.existingSecret` into the pod or emit `ssl.truststore.location` / `ssl.keystore.location` properties. Tracked for a follow-up lock-step release.
+
 ## [0.3.2] — 2026-05-23
 
 ### Fixed
@@ -116,7 +140,8 @@ First published release of the OpenNMS Helm Charts.
 - `core.postgresql.host` defaults to a CNPG-specific hostname (`cluster-helm-lint-rw.default.svc.cluster.local`) used by the in-repo chart-testing flow. Production users must set `postgresql.host` explicitly — the chart fails template-time on missing host.
 - The optional `prometheus-remote-writer` plugin is downloaded from GitHub Releases at every pod start when enabled. Air-gapped clusters override `prometheusRemoteWriter.kar.url` to an internal mirror.
 
-[Unreleased]: https://github.com/labmonkeys-space/opennms-helm-charts/compare/v0.3.2...HEAD
+[Unreleased]: https://github.com/labmonkeys-space/opennms-helm-charts/compare/v0.3.3...HEAD
+[0.3.3]: https://github.com/labmonkeys-space/opennms-helm-charts/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/labmonkeys-space/opennms-helm-charts/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/labmonkeys-space/opennms-helm-charts/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/labmonkeys-space/opennms-helm-charts/compare/v0.2.0...v0.3.0

--- a/charts/core/Chart.yaml
+++ b/charts/core/Chart.yaml
@@ -20,7 +20,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.2
+version: 0.3.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/core/README.md
+++ b/charts/core/README.md
@@ -1,6 +1,6 @@
 # core
 
-![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 36.0.0](https://img.shields.io/badge/AppVersion-36.0.0-informational?style=flat-square)
+![Version: 0.3.3](https://img.shields.io/badge/Version-0.3.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 36.0.0](https://img.shields.io/badge/AppVersion-36.0.0-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 
@@ -21,6 +21,7 @@ A Helm chart for Kubernetes
 | configRenderer.image.pullPolicy | string | `"IfNotPresent"` |  |
 | configRenderer.image.repository | string | `"docker.io/alpine"` |  |
 | configRenderer.image.tag | string | `"3.19"` |  |
+| daemons.ackd.enabled | bool | `false` |  |
 | elasticsearch.auth.existingSecret | string | `""` |  |
 | elasticsearch.connTimeout | int | `30000` |  |
 | elasticsearch.enableForwarding | bool | `true` |  |

--- a/charts/core/ci/test-values.yaml
+++ b/charts/core/ci/test-values.yaml
@@ -19,3 +19,13 @@ postgresql:
 # chart skips rendering Kafka cfg files. Core boots and its WebUI reaches
 # readiness; Kafka-using features will error in logs but won't block the
 # install or the wget smoke test.
+
+# Exercise the daemon-re-enable path end-to-end. Chart default is
+# `daemons.ackd.enabled: false` (Ackd is on the upstream deprecation track);
+# flipping back to `true` here verifies that the override silences the
+# CORE_SERVICE_ACKD_ENABLED env var so Karaf reaches the upstream default
+# (`enabled="true"` baked into service-configuration.xml). The readiness probe
+# on port 8101 still passes — Ackd is not on the boot critical path.
+daemons:
+  ackd:
+    enabled: true

--- a/charts/core/templates/_helpers.tpl
+++ b/charts/core/templates/_helpers.tpl
@@ -296,6 +296,15 @@ This helper is duplicated in sentinel/ and minion/ — keep them in sync.
     - |
       set -eu
       apk add --no-cache gettext >/dev/null
+      # Stale-overlay cleanup: chart ≤0.3.1 wrote four featuresBoot.d/kafka-*.boot
+      # files referencing IPC feature bundles that don't ship in any opennms/horizon
+      # image. 0.3.2 stopped writing them, but applyOverlayConfig is additive and
+      # the broken files survive on the PVC across upgrades — Karaf then fails to
+      # resolve the bundles at boot. Remove them explicitly on every pod start.
+      rm -f /opennms-data/etc/featuresBoot.d/kafka-ipc.boot \
+            /opennms-data/etc/featuresBoot.d/kafka-rpc.boot \
+            /opennms-data/etc/featuresBoot.d/kafka-sink.boot \
+            /opennms-data/etc/featuresBoot.d/kafka-twin.boot
       # ConfigMap data keys cannot contain "/", so subpaths under etc/ are
       # encoded with "__" in the key name and decoded back to "/" here.
       # Example: opennms.properties.d__timeseries.properties
@@ -321,6 +330,8 @@ This helper is duplicated in sentinel/ and minion/ — keep them in sync.
       mountPath: /tmp/templates
     - name: etc-overlay
       mountPath: /etc-overlay
+    - name: opennms-data
+      mountPath: /opennms-data
 {{- end }}
 
 {{/*
@@ -374,6 +385,48 @@ enabled (which routes time-series through the plugin), else the user's value.
 */}}
 {{- define "core.timeseriesStrategy" -}}
 {{- if .Values.prometheusRemoteWriter.enabled -}}integration{{- else -}}{{ .Values.timeseriesStrategy }}{{- end -}}
+{{- end }}
+
+{{/*
+Whitelist mapping chart-known daemon short names → upstream env-var stems.
+Disabling `core.daemons.<short>.enabled = false` projects
+`CORE_SERVICE_<STEM>_ENABLED=false` into both Core containers.
+
+Evidence the env-var path exists upstream (opennms/horizon:36.0.0
+/opt/opennms/etc/service-configuration.xml):
+
+  <service enabled="${env:CORE_SERVICE_ACKD_ENABLED|true}"><name>OpenNMS:Name=Ackd</name></service>
+
+To add the next daemon: append one entry below AND mention it in values.yaml.
+*/}}
+{{- define "core.daemonsEnvWhitelist" -}}
+ackd: ACKD
+{{- end }}
+
+{{/*
+Emits a YAML env list (zero or more entries) projecting CORE_SERVICE_<STEM>_ENABLED=false
+for each `core.daemons.<short>.enabled = false` entry. Entries left at the
+default `enabled: true` produce no env line (the upstream default already wins).
+
+Fails helm template if the operator references a short name not in the
+whitelist, with a message naming the bad key and listing valid names.
+*/}}
+{{- define "core.daemonsDisableEnv" -}}
+{{- $whitelist := fromYaml (include "core.daemonsEnvWhitelist" .) -}}
+{{- $validKeys := keys $whitelist | sortAlpha | join ", " -}}
+{{- range $short, $cfg := .Values.daemons }}
+{{- $stem := index $whitelist $short -}}
+{{- if not $stem -}}
+{{- fail (printf "core.daemons: unknown daemon %q — valid names are: %s" $short $validKeys) -}}
+{{- end }}
+{{- if not (hasKey $cfg "enabled") -}}
+{{- fail (printf "core.daemons.%s: missing required field 'enabled'" $short) -}}
+{{- end }}
+{{- if not $cfg.enabled }}
+- name: CORE_SERVICE_{{ $stem }}_ENABLED
+  value: "false"
+{{- end }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/core/templates/statefulset.yaml
+++ b/charts/core/templates/statefulset.yaml
@@ -85,6 +85,7 @@ spec:
                 name: {{ include "core.fullname" . }}-env
           env:
             {{- include "core.postgresEnv" . | nindent 12 }}
+            {{- include "core.daemonsDisableEnv" . | nindent 12 }}
           volumeMounts:
             - name: confd-overlay
               mountPath: /opt/opennms/horizon-config.yaml
@@ -108,6 +109,7 @@ spec:
                 name: {{ include "core.fullname" . }}-env
           env:
             {{- include "core.postgresEnv" . | nindent 12 }}
+            {{- include "core.daemonsDisableEnv" . | nindent 12 }}
           ports:
             - name: webui
               containerPort: 8980

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -280,6 +280,24 @@ elasticsearch:
     # Secret must contain keys: ELASTIC_USERNAME, ELASTIC_PASSWORD
     existingSecret: ""
 
+# Per-daemon enable/disable. Upstream service-configuration.xml wraps every
+# Core daemon's `enabled` attribute in ${env:CORE_SERVICE_<NAME>_ENABLED|<default>},
+# so flipping `enabled` here projects the matching env var into both
+# Core containers — no XML editing, no extra init containers.
+#
+# Unknown short names fail `helm template` with a clear error listing the
+# whitelist. Adding the next daemon: append one entry to
+# `core.daemonsEnvWhitelist` in _helpers.tpl AND one entry below. The current
+# whitelist holds only `ackd`; expand as operators ask for it.
+#
+# `ackd` defaults to `false`: the Acknowledgement Daemon is on the upstream
+# deprecation track and is not used by most deployments. Operators who rely on
+# alarm acknowledgement workflows that depend on Ackd should set
+# `daemons.ackd.enabled: true` here.
+daemons:
+  ackd:
+    enabled: false
+
 # Escape hatch: arbitrary additional .cfg / .properties files written into
 # the etc-overlay alongside chart-managed files. Keys are natural POSIX paths
 # *relative to etc/*; subdirectories work as you'd expect.

--- a/charts/minion/Chart.yaml
+++ b/charts/minion/Chart.yaml
@@ -20,7 +20,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.2
+version: 0.3.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/minion/README.md
+++ b/charts/minion/README.md
@@ -1,6 +1,6 @@
 # minion
 
-![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 36.0.0](https://img.shields.io/badge/AppVersion-36.0.0-informational?style=flat-square)
+![Version: 0.3.3](https://img.shields.io/badge/Version-0.3.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 36.0.0](https://img.shields.io/badge/AppVersion-36.0.0-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 

--- a/charts/opennms-stack/Chart.lock
+++ b/charts/opennms-stack/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: core
   repository: file://../core
-  version: 0.3.2
+  version: 0.3.3
 - name: sentinel
   repository: file://../sentinel
-  version: 0.3.2
-digest: sha256:4f81c27fa64a384f846ff784aafc595828df56696cc9e91be11c6a4ee17ea87b
-generated: "2026-05-23T22:25:15.394006+02:00"
+  version: 0.3.3
+digest: sha256:21804dbcd8e247e279e050c41832a4f121c19b41d0c85d235f2ba9e9f1112564
+generated: "2026-05-24T11:34:28.366832+02:00"

--- a/charts/opennms-stack/Chart.yaml
+++ b/charts/opennms-stack/Chart.yaml
@@ -14,7 +14,7 @@ maintainers:
 type: application
 
 # Bump this version whenever any pinned subchart version changes.
-version: 0.3.2
+version: 0.3.3
 
 # Lock-step with the bundled OpenNMS components (Core and Sentinel both run
 # this version of Horizon).
@@ -25,8 +25,8 @@ appVersion: "36.0.0"
 # features — is enforced here at the umbrella level.
 dependencies:
   - name: core
-    version: "=0.3.2"
+    version: "=0.3.3"
     repository: file://../core
   - name: sentinel
-    version: "=0.3.2"
+    version: "=0.3.3"
     repository: file://../sentinel

--- a/charts/opennms-stack/README.md
+++ b/charts/opennms-stack/README.md
@@ -1,6 +1,6 @@
 # opennms-stack
 
-![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 36.0.0](https://img.shields.io/badge/AppVersion-36.0.0-informational?style=flat-square)
+![Version: 0.3.3](https://img.shields.io/badge/Version-0.3.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 36.0.0](https://img.shields.io/badge/AppVersion-36.0.0-informational?style=flat-square)
 
 Umbrella Helm chart bundling OpenNMS Horizon Core and Sentinel for the
 central OpenNMS site. Connects to BYO Postgres, Kafka, and Elasticsearch.
@@ -17,8 +17,8 @@ this umbrella.
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../core | core | =0.3.2 |
-| file://../sentinel | sentinel | =0.3.2 |
+| file://../core | core | =0.3.3 |
+| file://../sentinel | sentinel | =0.3.3 |
 
 ## Values
 

--- a/charts/opennms-stack/ci/test-values.yaml
+++ b/charts/opennms-stack/ci/test-values.yaml
@@ -34,6 +34,12 @@ core:
   # Skip the 50Gi PVC in kind — no default storage class.
   persistence:
     enabled: false
+  # Exercise the daemon-re-enable path through the umbrella's sub-values.
+  # Chart default is `daemons.ackd.enabled: false`; this flip back to `true`
+  # mirrors charts/core/ci/test-values.yaml.
+  daemons:
+    ackd:
+      enabled: true
 
 sentinel:
   replicaCount: 1

--- a/charts/sentinel/Chart.yaml
+++ b/charts/sentinel/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.2
+version: 0.3.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/sentinel/README.md
+++ b/charts/sentinel/README.md
@@ -1,6 +1,6 @@
 # sentinel
 
-![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 36.0.0](https://img.shields.io/badge/AppVersion-36.0.0-informational?style=flat-square)
+![Version: 0.3.3](https://img.shields.io/badge/Version-0.3.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 36.0.0](https://img.shields.io/badge/AppVersion-36.0.0-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 


### PR DESCRIPTION
## Summary

Ships chart **0.3.3** lock-step across `core`, `sentinel`, `minion`, `opennms-stack`.

- **Bugfix:** Core now removes stale `featuresBoot.d/kafka-{ipc,rpc,sink,twin}.boot` files from `/opennms-data/etc/` on every pod start. 0.3.2 stopped *writing* them but the upstream entrypoint's `applyOverlayConfig` is additive — files removed from the chart's overlay between releases survive on the PVC, and Karaf then fails to resolve the IPC bundles at boot (`Error resolving artifact org.opennms.core.ipc.rpc:org.opennms.core.ipc.rpc.kafka:jar:36.0.0`). Reported live on a 0.3.1 → 0.3.2 upgrade and verified.
- **Feature:** New `core.daemons.<short>.enabled` values surface. Upstream `etc/service-configuration.xml` wraps every daemon in `${env:CORE_SERVICE_<NAME>_ENABLED|<default>}`, so disable is an env-var projection on both Core containers — no XML editing, no extra init container, no init image expansion. Whitelist-validated. First wired daemon: `ackd`.

## Breaking changes (0.3.2 → 0.3.3)

- `core.daemons.ackd.enabled` defaults to **false** — Ackd is on the upstream deprecation track and most deployments don't use it. Operators who still rely on Ackd MUST set `core.daemons.ackd.enabled: true` before upgrading.
- Operator-supplied `extraConfigFiles."featuresBoot.d/kafka-{ipc,rpc,sink,twin}.boot"` content is now deleted at every pod start. The cleanup runs unconditionally on exact filenames. Rename to non-conflicting paths if you depend on bespoke kafka boot files (unlikely — the bundles don't ship in any Horizon 35/36 image).

See `CHANGELOG.md [0.3.3]` for the full impact + mitigation notes.

## Test plan

- [x] `helm lint charts/{core,sentinel,minion,opennms-stack}` — all clean.
- [x] `helm template charts/core` (defaults) — renders the four `rm -f` lines + `CORE_SERVICE_ACKD_ENABLED=false` on both core-init and core containers.
- [x] `helm template charts/core --set daemons.ackd.enabled=true` — env var absent (upstream default takes effect).
- [x] `helm template charts/core --set daemons.notARealDaemon.enabled=false` — fails with `core.daemons: unknown daemon "notARealDaemon" — valid names are: ackd`.
- [x] `helm template charts/opennms-stack --set core.daemons.ackd.enabled=true` — env-var override propagates correctly through the umbrella.
- [x] Cleanup `rm -f` block renders with kafka set AND kafka unset (unconditional).
- [x] Manual verification on the bbo-blinkenlights deployment (chart 0.3.2): reproduced the bundle-resolution boot failure; manual cleanup of `/opt/opennms-etc-overlay/featuresBoot.d/` + pod bounce → Karaf boots cleanly. This PR automates that cleanup via the envsubst init container.
- [ ] End-to-end kind upgrade test: install 0.3.1 with `kafka.bootstrapServers` set → `helm upgrade` to 0.3.3 → confirm Karaf boots and the four stale boot files are gone from the PVC. (Operator follow-up.)
- [ ] CI `ct install` against the updated `ci/test-values.yaml` (exercises the re-enable override path). (Runs on this PR.)

## Notes

- DCO signoff to be added by maintainer (`git commit --amend --signoff` before merge).
- `openspec/changes/add-core-daemon-toggles-and-overlay-cleanup/` artifacts (proposal, design, specs, tasks) are not committed — this repo gitignores `openspec/`.