### PR TITLE
fix(core): make webAdmin bootstrap actually work with onmsctl (0.3.10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). All
 
 (no unreleased changes yet)
 
+## [0.3.10] — 2026-07-08
+
+### Fixed
+
+- **`core`** — the Web UI admin-password bootstrap hook shipped in 0.3.9 never succeeded; a fresh `helm install` failed at the `post-install` hook (`Job Failed`). Two `onmsctl` integration bugs, both found via a live kind e2e against `opennms/horizon:36.0.0` + `onmsctl:0.4.2`:
+  1. **onmsctl requires a config file.** The `ONMS_URL`/`ONMS_USER`/`ONMS_PASSWORD` env vars the hook passed are only overrides on top of a *loaded context*, so onmsctl exited 2 (`config file not found …`) before issuing any REST call. The hook now renders and mounts an onmsctl config ConfigMap (`<release>-core-webadmin-onmsctl` — a `bootstrap` context carrying the Core URL and the public default `admin`/`admin` login) and sets `ONMSCTL_CONFIG`.
+  2. **onmsctl refuses symlinked `--from-file` targets, and Kubernetes secret volume mounts are symlinks** (the `..data` indirection), so `--from-file /seed/password` always failed. The generated password is now delivered via `--from-env` (projected with a `secretKeyRef`); the secret volume mount and the `fsGroup`/`defaultMode: 0440` handling are removed.
+  Additionally, the init container now waits on the authenticated `/opennms/rest/users` endpoint (200 for `admin`/`admin`) instead of `login.jsp`, so onmsctl no longer races ahead of a REST layer that Jetty reports "up" before it can serve. Verified end-to-end on kind: fresh install rotates the password, `admin`/`admin` → 401, the Secret's password → 200.
+- **All four charts** — strict-pin cascade 0.3.9 → 0.3.10. Umbrella `dependencies` updated to `=0.3.10`. `sentinel`, `minion`, and `opennms-stack` chart contents are unchanged (version bump only).
+
 ## [0.3.9] — 2026-07-08
 
 ### Added
@@ -268,7 +278,8 @@ First published release of the OpenNMS Helm Charts.
 - `core.postgresql.host` defaults to a CNPG-specific hostname (`cluster-helm-lint-rw.default.svc.cluster.local`) used by the in-repo chart-testing flow. Production users must set `postgresql.host` explicitly — the chart fails template-time on missing host.
 - The optional `prometheus-remote-writer` plugin is downloaded from GitHub Releases at every pod start when enabled. Air-gapped clusters override `prometheusRemoteWriter.kar.url` to an internal mirror.
 
-[Unreleased]: https://github.com/labmonkeys-space/opennms-helm-charts/compare/v0.3.9...HEAD
+[Unreleased]: https://github.com/labmonkeys-space/opennms-helm-charts/compare/v0.3.10...HEAD
+[0.3.10]: https://github.com/labmonkeys-space/opennms-helm-charts/compare/v0.3.9...v0.3.10
 [0.3.9]: https://github.com/labmonkeys-space/opennms-helm-charts/compare/v0.3.8...v0.3.9
 [0.3.8]: https://github.com/labmonkeys-space/opennms-helm-charts/compare/v0.3.7...v0.3.8
 [0.3.7]: https://github.com/labmonkeys-space/opennms-helm-charts/compare/v0.3.6...v0.3.7

--- a/charts/core/Chart.yaml
+++ b/charts/core/Chart.yaml
@@ -20,7 +20,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.9
+version: 0.3.10
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/core/README.md
+++ b/charts/core/README.md
@@ -1,6 +1,6 @@
 # core
 
-![Version: 0.3.9](https://img.shields.io/badge/Version-0.3.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 36.0.0](https://img.shields.io/badge/AppVersion-36.0.0-informational?style=flat-square)
+![Version: 0.3.10](https://img.shields.io/badge/Version-0.3.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 36.0.0](https://img.shields.io/badge/AppVersion-36.0.0-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 

--- a/charts/core/templates/webadmin-bootstrap-job.yaml
+++ b/charts/core/templates/webadmin-bootstrap-job.yaml
@@ -1,10 +1,22 @@
 {{- /*
 Post-install hook that bootstraps the Web UI `admin` password (see design.md
 D1/D3). Runs at INSTALL ONLY (`post-install`, not `post-upgrade`), so an
-upgrade never re-rotates the password. An init container waits for Core's
-WebUI/REST to accept requests, then the onmsctl container authenticates as the
-upstream default admin/admin and sets the password to the value in the Secret
-via Horizon's UserRestService (`hashPassword=true` → server hashes it).
+upgrade never re-rotates the password.
+
+onmsctl integration constraints (verified against onmsctl 0.4.2 on a live
+kind cluster):
+  - onmsctl REQUIRES a config file; `ONMS_*` env vars are only overrides on
+    top of a loaded context. We mount one (the `-webadmin-onmsctl` ConfigMap)
+    and point ONMSCTL_CONFIG at it. The context's basic auth is the upstream
+    default admin/admin — the public bootstrap login this hook replaces.
+  - The new password is delivered with `--from-env`, NOT `--from-file`:
+    onmsctl refuses symlinked secret files, and Kubernetes secret volume
+    mounts are always symlinks (the `..data` indirection). We project the
+    password via a secretKeyRef env var instead.
+
+The init container waits until the authenticated REST surface onmsctl uses
+(`/opennms/rest/users` with admin/admin) returns 200 — this is stronger than
+polling login.jsp, which Jetty serves before the REST layer is ready.
 
 Idempotency: the call authenticates as admin/admin, valid on a fresh install.
 backoffLimit retries are safe as long as the password has not yet been changed
@@ -48,21 +60,17 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      # Non-root, restricted-friendly. fsGroup makes the mounted Secret
-      # group-readable so the onmsctl container (uid 65534) can read it; the
-      # 0440 mode keeps onmsctl's "readable beyond owner" from being a hard
-      # refusal (it only warns). See design.md verify 1.5.
+      # Non-root, restricted-friendly. No fsGroup needed: the password is
+      # projected via a secretKeyRef env var, not a mounted (symlinked) file.
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534
         runAsGroup: 65534
-        fsGroup: 65534
         seccompProfile:
           type: RuntimeDefault
       initContainers:
-        # Wait for Core's WebUI/REST to accept requests before authenticating.
-        # Polls login.jsp (unauthenticated 200) — the same target as the
-        # chart's readinessProbe. See design.md D3 / verify 1.4.
+        # Wait until the authenticated REST endpoint onmsctl uses is actually
+        # serving (200 for admin/admin), not just login.jsp. See design.md D3.
         - name: wait-for-core
           image: "{{ .Values.configRenderer.image.repository }}:{{ .Values.configRenderer.image.tag }}"
           imagePullPolicy: {{ .Values.configRenderer.image.pullPolicy | quote }}
@@ -76,9 +84,10 @@ spec:
             - -c
             - |
               set -eu
-              url="http://{{ include "core.fullname" . }}:{{ .Values.service.webui.port }}/opennms/login.jsp"
+              auth="$(printf '%s' 'admin:admin' | base64 | tr -d '\n')"
+              url="http://{{ include "core.fullname" . }}:{{ .Values.service.webui.port }}/opennms/rest/users"
               i=0
-              until wget -q -O /dev/null "$url"; do
+              until wget -q -O /dev/null --header="Authorization: Basic $auth" "$url"; do
                 i=$((i+1))
                 if [ "$i" -ge {{ .Values.webAdmin.readiness.retries }} ]; then
                   echo "core REST not ready after {{ .Values.webAdmin.readiness.retries }} attempts" >&2
@@ -101,30 +110,22 @@ spec:
             - user
             - set-password
             - {{ .Values.webAdmin.username | quote }}
-            - --from-file
-            - /seed/password
+            - --from-env
+            - WEBADMIN_NEW_PASSWORD
           env:
-            - name: ONMS_URL
-              value: "http://{{ include "core.fullname" . }}:{{ .Values.service.webui.port }}/opennms"
-            # First-boot authentication uses the upstream default admin/admin —
-            # a public default, not a secret. The set-password call replaces it.
-            - name: ONMS_USER
-              value: "admin"
-            - name: ONMS_PASSWORD
-              value: "admin"
+            - name: ONMSCTL_CONFIG
+              value: /etc/onmsctl/config.yaml
+            - name: WEBADMIN_NEW_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "core.webAdminSecretName" . | quote }}
+                  key: {{ .Values.webAdmin.existingSecretPasswordKey | quote }}
           volumeMounts:
-            - name: seed
-              mountPath: /seed
+            - name: onmsctl-config
+              mountPath: /etc/onmsctl
               readOnly: true
       volumes:
-        - name: seed
-          secret:
-            secretName: {{ include "core.webAdminSecretName" . | quote }}
-            defaultMode: 0440
-            items:
-              # For a BYO existingSecret the password may live under a
-              # different key; always project it to the fixed path /seed/password.
-              # Source key defaults to `password` (values.yaml).
-              - key: {{ .Values.webAdmin.existingSecretPasswordKey }}
-                path: password
+        - name: onmsctl-config
+          configMap:
+            name: {{ include "core.fullname" . }}-webadmin-onmsctl
 {{- end }}

--- a/charts/core/templates/webadmin-onmsctl-config.yaml
+++ b/charts/core/templates/webadmin-onmsctl-config.yaml
@@ -1,0 +1,34 @@
+{{- /*
+onmsctl config file for the admin-password bootstrap hook. onmsctl 0.4.2
+requires a config file to exist (env vars are only overrides on top of a
+loaded context), so the hook Job mounts this and points ONMSCTL_CONFIG at it.
+
+The context's basic auth is the upstream default admin/admin — the public
+first-boot login the hook replaces, not a secret. Rendered as a `post-install`
+hook (weight 0, before the Job at weight 5) and cleaned up on success.
+*/ -}}
+{{- if .Values.webAdmin.enabled }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "core.fullname" . }}-webadmin-onmsctl
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "core.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+data:
+  config.yaml: |
+    current-context: bootstrap
+    contexts:
+      - name: bootstrap
+        server:
+          url: http://{{ include "core.fullname" . }}:{{ .Values.service.webui.port }}/opennms
+        auth:
+          basic:
+            username: admin
+            password: admin
+{{- end }}

--- a/charts/minion/Chart.yaml
+++ b/charts/minion/Chart.yaml
@@ -20,7 +20,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.9
+version: 0.3.10
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/minion/README.md
+++ b/charts/minion/README.md
@@ -1,6 +1,6 @@
 # minion
 
-![Version: 0.3.9](https://img.shields.io/badge/Version-0.3.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 36.0.0](https://img.shields.io/badge/AppVersion-36.0.0-informational?style=flat-square)
+![Version: 0.3.10](https://img.shields.io/badge/Version-0.3.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 36.0.0](https://img.shields.io/badge/AppVersion-36.0.0-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 

--- a/charts/opennms-stack/Chart.lock
+++ b/charts/opennms-stack/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: core
   repository: file://../core
-  version: 0.3.9
+  version: 0.3.10
 - name: sentinel
   repository: file://../sentinel
-  version: 0.3.9
-digest: sha256:ba850c60ae7a7a58cd2ee85cd79e23e4e0986fbc784ce7024a634f0200bd7a2e
-generated: "2026-07-08T13:50:53.103817+02:00"
+  version: 0.3.10
+digest: sha256:4318a3c137f326a71a0ba78417f01ad3b96a1e0b9422faed0578a3f83cf10643
+generated: "2026-07-08T23:14:51.068892+02:00"

--- a/charts/opennms-stack/Chart.yaml
+++ b/charts/opennms-stack/Chart.yaml
@@ -14,7 +14,7 @@ maintainers:
 type: application
 
 # Bump this version whenever any pinned subchart version changes.
-version: 0.3.9
+version: 0.3.10
 
 # Lock-step with the bundled OpenNMS components (Core and Sentinel both run
 # this version of Horizon).
@@ -25,8 +25,8 @@ appVersion: "36.0.0"
 # features — is enforced here at the umbrella level.
 dependencies:
   - name: core
-    version: "=0.3.9"
+    version: "=0.3.10"
     repository: file://../core
   - name: sentinel
-    version: "=0.3.9"
+    version: "=0.3.10"
     repository: file://../sentinel

--- a/charts/opennms-stack/README.md
+++ b/charts/opennms-stack/README.md
@@ -1,6 +1,6 @@
 # opennms-stack
 
-![Version: 0.3.9](https://img.shields.io/badge/Version-0.3.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 36.0.0](https://img.shields.io/badge/AppVersion-36.0.0-informational?style=flat-square)
+![Version: 0.3.10](https://img.shields.io/badge/Version-0.3.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 36.0.0](https://img.shields.io/badge/AppVersion-36.0.0-informational?style=flat-square)
 
 Umbrella Helm chart bundling OpenNMS Horizon Core and Sentinel for the
 central OpenNMS site. Connects to BYO Postgres, Kafka, and Elasticsearch.
@@ -17,8 +17,8 @@ this umbrella.
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../core | core | =0.3.9 |
-| file://../sentinel | sentinel | =0.3.9 |
+| file://../core | core | =0.3.10 |
+| file://../sentinel | sentinel | =0.3.10 |
 
 ## Values
 

--- a/charts/sentinel/Chart.yaml
+++ b/charts/sentinel/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.9
+version: 0.3.10
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/sentinel/README.md
+++ b/charts/sentinel/README.md
@@ -1,6 +1,6 @@
 # sentinel
 
-![Version: 0.3.9](https://img.shields.io/badge/Version-0.3.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 36.0.0](https://img.shields.io/badge/AppVersion-36.0.0-informational?style=flat-square)
+![Version: 0.3.10](https://img.shields.io/badge/Version-0.3.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 36.0.0](https://img.shields.io/badge/AppVersion-36.0.0-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 


### PR DESCRIPTION
## Why

The Web UI admin-password bootstrap shipped in **0.3.9** (#13) **never worked** — a fresh `helm install` of `core` fails at the `post-install` hook (`Job Failed`). Found by running the kind e2e for real (the one path CI doesn't exercise, since CI sets `webAdmin.enabled=false`). Two independent onmsctl integration bugs, both confirmed on a live cluster (`opennms/horizon:36.0.0` + `onmsctl:0.4.2`):

1. **onmsctl requires a config file.** The `ONMS_URL`/`ONMS_USER`/`ONMS_PASSWORD` env vars the hook passed are only *overrides on top of a loaded context*, so onmsctl exited 2 (`config file not found …`) before making any REST call.
2. **onmsctl refuses symlinked `--from-file` targets, and Kubernetes secret volume mounts are symlinks** (the `..data` indirection) — so `--from-file /seed/password` always failed.

## What changed

- New **`-webadmin-onmsctl` ConfigMap** (a `bootstrap` context: Core URL + the public `admin`/`admin` login), mounted into the hook with `ONMSCTL_CONFIG` set.
- Password now delivered via **`--from-env`** (projected with a `secretKeyRef`), not `--from-file`. The secret volume mount and the `fsGroup`/`defaultMode: 0440` handling are **removed** (simpler than 0.3.9).
- Init wait now polls the **authenticated `/opennms/rest/users`** (200 for `admin`/`admin`) instead of `login.jsp`, closing the readiness race where Jetty reports "up" before REST can serve.
- Lock-step bump all four charts `0.3.9 → 0.3.10`.

## Test — live kind e2e (this is the validation the 0.3.9 PR lacked)

| Case | Result |
|---|---|
| **8.1** fresh install | ✅ `STATUS: deployed`, hook succeeded; `admin/admin → 401`, Secret password → `200` |
| **1.3** onmsctl rotates its own admin pw | ✅ `password updated for 'admin'` (self-lockout guard permits it) |
| **1.4** login.jsp-vs-REST race | ✅ init waits on `rest/users`; onmsctl no longer races |
| **1.5** non-root under restricted ctx | ✅ ran as uid 65534, read config + env password |
| **8.2** `helm upgrade` | ✅ hook does **not** re-run; Secret password unchanged; `admin/admin` still `401` |
| **8.3** BYO `existingSecret` / **8.4** disabled | ✅ `helm template`-verified |

Plus `helm lint` clean on all four charts and `helm template` render checks (ConfigMap present, `--from-env`/`ONMSCTL_CONFIG` wired, no `--from-file`).

## Note

This supersedes the broken default-on path from 0.3.9. Recommend merging promptly (or, if you prefer a stopgap first, `webAdmin.enabled` can be flipped to default-off — say the word and I'll add that instead/as well).

🤖 Generated with [Claude Code](https://claude.com/claude-code)