### PR TITLE
docs(dependabot): record that ghcr onmsctl tracking is verified

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,10 +37,13 @@ updates:
   # charts do. Tracks the onmsctl bootstrap image (webAdmin.image) and, as a
   # side effect, the existing alpine config-renderer pin in charts/core.
   #
-  # CAVEAT (dependabot-core #12207): the Helm/docker updater has been reported
-  # to query Docker Hub instead of the real registry for non-docker.io images.
-  # onmsctl lives on ghcr.io — verify a bump PR actually appears; if not, fall
-  # back to a scheduled tag-poll workflow (see change tasks 7.5).
+  # VERIFIED (2026-07-08, Dependabot `docker in /charts/core` run log): the
+  # updater queries ghcr.io directly for onmsctl (tags/list + manifests → 200)
+  # and docker.io for alpine, and opens bump PRs correctly (alpine 3.19 → 3.24,
+  # PR #14). dependabot-core #12207 (Helm/docker updater querying Docker Hub for
+  # non-docker.io registries) does NOT affect this setup, so no tag-poll
+  # fallback is needed. onmsctl produces no PR only because the pin already
+  # tracks its latest tag.
   - package-ecosystem: "docker"
     directory: "/charts/core"
     schedule:


### PR DESCRIPTION
Comment-only update to `.github/dependabot.yml`.

The `docker` ecosystem entry carried a speculative caveat about dependabot-core [#12207](https://github.com/dependabot/dependabot-core/issues/12207) (the Helm/docker updater querying Docker Hub for non-`docker.io` images). Inspecting the actual Dependabot run log shows that concern **does not apply here**:

```
Checking if no42-org/onmsctl 0.4.2 needs updating
proxy GET  https://ghcr.io/v2/no42-org/onmsctl/tags/list        → 200
proxy HEAD https://ghcr.io/v2/no42-org/onmsctl/manifests/latest → 200
proxy HEAD https://ghcr.io/v2/no42-org/onmsctl/manifests/0.4.2  → 200
```

Dependabot queries **ghcr.io** directly for onmsctl and **docker.io** for alpine, and opens bump PRs correctly (the same run opened #14 bumping alpine `3.19 → 3.24`). onmsctl shows no PR only because the pin (`0.4.2`) already tracks its latest tag.

This replaces the "verify a bump PR appears / else build a tag-poll fallback" note with the verified finding, so a future maintainer doesn't chase a non-issue. No chart change; no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)